### PR TITLE
feat(bioemu-benchmarks): make filtering faster

### DIFF
--- a/bioemu_benchmarks/utils.py
+++ b/bioemu_benchmarks/utils.py
@@ -190,6 +190,11 @@ def _compute_filtered_contacts(
     a cutoff will be considered for the final contact computation, reducing the number of contacts
     considered significantly. This should speed up contact computation by a factor of ten.
 
+    NOTE: This filtering assumes that all atoms in a residue will be distorted together with the Ca.
+    It will e.g. not detect a single N from a residue colliding with something far away if the
+    remaining atoms behave normally. However, this situation should not happen as we use a rigid
+    frame based representation and MD data should be fine as well due to the harmonic potentials.
+
     Args:
         trajectory: Trajectory to compute contacts for.
         ca_clash_cutoff: Cutoff used for Ca based prefiltering. Units are Angstrom.

--- a/tests/eval/multiconf/test_utils.py
+++ b/tests/eval/multiconf/test_utils.py
@@ -17,8 +17,12 @@ def test_filter_unphysical_traj() -> None:
     traj = filter_unphysical_traj(traj, strict=True)
     assert traj.n_frames == 1
 
-    # Modify one coord so that it's rejected. Generate a fake clash
-    traj.xyz[:, 0, :] = traj.xyz[:, 20, :]
+    # Modify one coord so that it's rejected. Generate a fake clash.
+    # NOTE: our clash filter assumes rigid frames and prefilters based on Ca for sake of efficiency.
+    # Because of this, we make the first and last full non-glycine residue clash (residues have
+    # 5 atoms due to C beta).
+    idx_no_glycine = traj.top.select("not resname GLY")
+    traj.xyz[:, idx_no_glycine[:5], :] = traj.xyz[:, idx_no_glycine[-5:], :]
 
     with pytest.raises(AssertionError):
         filter_unphysical_traj(traj, strict=True)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,55 @@
+from pathlib import Path
+
+import mdtraj
+import numpy as np
+import pytest
+
+from bioemu_benchmarks.benchmarks import Benchmark
+from bioemu_benchmarks.samples import IndexedSamples, find_samples_in_dir
+from bioemu_benchmarks.utils import _compute_filtered_contacts
+
+from . import TEST_DATA_DIR
+
+CLASH_DISTANCE = 1.0
+CA_FILTER_CUTOFF = 2 * 2.5 + CLASH_DISTANCE  # 2 x Ca-O in frame + clash
+
+
+@pytest.fixture
+def samples_path() -> Path:
+    test_data_path = Path(TEST_DATA_DIR) / "samples_example" / "md_emulation"
+    return test_data_path
+
+
+def test_compute_filtered_contacts(samples_path):
+    """
+    Check in mdtraj native `compute_contacts` and internal routine with filtering based on Ca
+    distances lead to the same masks.
+    """
+    sequence_samples = find_samples_in_dir(samples_path)
+    indexed_samples = IndexedSamples.from_benchmark(
+        Benchmark.MD_EMULATION, sequence_samples=sequence_samples
+    )
+
+    samples_traj = indexed_samples.get_trajs_for_test_case("cath1_1bl0A02")[0]
+
+    # Make atoms in first frame clash.
+    samples_traj.xyz[0, -5:] -= 0.4
+    has_clashes_expected = np.array([False] + [True] * (len(samples_traj) - 1))
+
+    def _get_frames_non_clash(distances: np.ndarray) -> np.ndarray:
+        return np.all(
+            mdtraj.utils.in_units_of(distances, "nanometers", "angstrom") > CLASH_DISTANCE, axis=1
+        )
+
+    # Routine with prefiltering.
+    distances_test, _ = _compute_filtered_contacts(
+        samples_traj, ca_clash_cutoff=CA_FILTER_CUTOFF, sequence_separation=2
+    )
+    frames_non_clash_test = _get_frames_non_clash(distances_test)
+
+    # Basic mdtraj routine.
+    distances_target, _ = mdtraj.compute_contacts(samples_traj, periodic=False)
+    frames_non_clash_target = _get_frames_non_clash(distances_target)
+
+    np.testing.assert_equal(frames_non_clash_test, frames_non_clash_target)
+    np.testing.assert_equal(frames_non_clash_test, has_clashes_expected)


### PR DESCRIPTION
Add prefiltering based on Ca distances before checking contacts on all atoms which was the most time intensive step in the procedure. Filter behavior remains the same, but speed should be a factor of 10 faster and memory requirement lower (especially for larger systems).

#### Example on domain motion
Old:
![image](https://github.com/user-attachments/assets/c8c01d59-2328-4ad2-bcc7-25996a9fe8be)
New:
![image](https://github.com/user-attachments/assets/e5c0e2bc-e29c-4a31-9f85-f09246b3d387)

>[!NOTE]
> This filtering assumes that all atoms in a residue will be distorted together with the Ca. It will e.g. not detect a single N from a residue colliding with something far away if the remaining atoms behave normally. However, this situation should not happen as we use a rigid frame based representation and MD data should be fine as well due to the harmonic potentials.