### PR TITLE
Harden publish workflow: split build/publish, pin pypi-publish action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,13 +6,12 @@ on:
 
 permissions:
   contents: read
-  id-token: write
 
 jobs:
-  deploy:
+  build:
     runs-on: ubuntu-latest
-    environment: publish-to-pypi
-
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
@@ -28,11 +27,30 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install --upgrade build twine
+          python -m pip install --upgrade build
 
       - name: Build
         run: |
           python -m build
 
+      - name: Upload built distributions
+        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+        with:
+          name: dist
+          path: dist/
+
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    environment: publish-to-pypi
+    permissions:
+      id-token: write  # for trusted publishing
+    steps:
+      - name: Download built distributions
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
+        with:
+          name: dist
+          path: dist/
+
       - name: Publish
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@7f25271a4aa483500f742f9492b2ab5648d61011 # v1.12.4


### PR DESCRIPTION
Hardens the PyPI publish workflow (`publish.yml`).

## Changes
- **Separate build and publish** into two jobs:
  - `build` runs with `contents: read` only (no `id-token`), builds the sdist/wheel, and uploads them as an artifact.
  - `publish` `needs: build`, runs under the `publish-to-pypi` environment, holds `id-token: write`, and downloads the artifact instead of rebuilding.
  - Keeps the OIDC publishing identity off the build step, so a compromised build can't publish.
- **Pin `pypa/gh-action-pypi-publish`** to a commit SHA (`7f25271…` = v1.12.4) — was `@release/v1` (mutable). `checkout` and `setup-python` were already pinned.
- Drop the unused `twine` dependency.

## Related hardening (already applied directly, outside this PR)
- `publish-to-pypi` environment now requires review by **ai4s-bioemu** (`prevent_self_review`, no admin bypass).
- Added a `v*` **tag protection ruleset** (creation restricted to ai4s-bioemu).
- Hardened the `main` branch ruleset (`dismiss_stale_reviews_on_push` + `require_last_push_approval`).

Tracked in msr-ai4science/feynman#21953.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>